### PR TITLE
Add .gitattributes to avoid changes of line endings with autocrlf true

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+provision/files/** -text

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !/docs
 !/install
 !/provision
+!/.gitattributes
 !/.gitignore
 !/README.md
 !/Vagrantfile


### PR DESCRIPTION
Please regard adding this commit. It prevents git to change the line endings for files in provision/files with activated option autocrlf true. Without this commit you'll get an error message when connection to the virtual machine because .bashrc has invalid line endings.
There might also be other files where git should never change the line endings, but this change solved the problem for me.
